### PR TITLE
Make it reproduce issue with native-image as well

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <kotlin.version>1.7.10</kotlin.version>
 	<!-- <kotlin.version>1.7.10</kotlin.version> !-->
         <junit.version>4.13.1</junit.version>
-        <main.class>kotlin.TestKt</main.class>
+        <main.class>hello.JavaHello</main.class>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 mvn clean package
-java -cp ./target/mixed-code-hello-world-1.0-SNAPSHOT-jar-with-dependencies.jar hello.JavaHello
+java -jar ./target/mixed-code-hello-world-1.0-SNAPSHOT-jar-with-dependencies.jar
+native-image --link-at-build-time --initialize-at-build-time=. -jar target/mixed-code-hello-world-1.0-SNAPSHOT-jar-with-dependencies.jar

--- a/src/main/kotlin/hello/Test.kt
+++ b/src/main/kotlin/hello/Test.kt
@@ -13,9 +13,10 @@ var baz: Int by Delegates.vetoable(0) { property, oldValue, newValue ->
 
 val KotlinHelloString : String = "Hello from Kotlin!"
 
+val g = Class.forName("hello.Test\$special\$\$inlined\$vetoable\$1").declaringClass
+val f = Class.forName("hello.Test\$special\$\$inlined\$sortedByDescending\$1").declaringClass
+
 fun getHelloStringFromJava() : String {
-    val g = Class.forName("hello.Test\$special\$\$inlined\$vetoable\$1").declaringClass
-    val f = Class.forName("hello.Test\$special\$\$inlined\$sortedByDescending\$1").declaringClass
     println(g)
     println(f)
     val x = Test()


### PR DESCRIPTION
Moved the `getDeclaringClass` invocations in the class initializer to trigger the exception when building a native image.